### PR TITLE
Fixed problems with RealmSwift & CocoaPods

### DIFF
--- a/RealmSwift Test App.xcodeproj/project.pbxproj
+++ b/RealmSwift Test App.xcodeproj/project.pbxproj
@@ -473,12 +473,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 04F49B18B177577EB1FC715A /* Pods-RealmSwift Test App.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "RealmSwift Test App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "RealmSwift Test App/BridgingHeader.h";
-				USER_HEADER_SEARCH_PATHS = "Pods/**";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Debug;
 		};
@@ -486,12 +487,13 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71A3666D1217392F357F94D0 /* Pods-RealmSwift Test App.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "RealmSwift Test App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "RealmSwift Test App/BridgingHeader.h";
-				USER_HEADER_SEARCH_PATHS = "Pods/**";
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				USER_HEADER_SEARCH_PATHS = "";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The problem is that CocoaPods doesn't support mixing dynamic frameworks (`use_frameworks!`) with static frameworks (standard).

This PR makes the following changes to the project's build settings:
- `ALWAYS_SEARCH_USER_PATHS = NO`
- `SWIFT_OBJC_BRIDGING_HEADER = ""`
- `USER_HEADER_SEARCH_PATHS = ""`

Now because the Evernote SDK's podspec isn't set up to work with `use_frameworks!`, it means you won't be able to use it. This is a general CocoaPods limitation: dynamic and static frameworks can't be mixed.
